### PR TITLE
WP-10 : Déplacer le SHA postfinance vers wp-config

### DIFF
--- a/cf7-pf_oli_klay/cf7-pf_oli.php
+++ b/cf7-pf_oli_klay/cf7-pf_oli.php
@@ -308,7 +308,7 @@ class donationForm {
         $arrayToHash = array();
         foreach ($form as $key => $value) {
             if ($value != '') {
-                $arrayToHash[] = strtoupper($key) . '=' . $value . 'stc0mp45510nypg3in2';
+                $arrayToHash[] = strtoupper($key) . '=' . $value . POSTFINANCE_SHA_IN;
             }
         }
         asort($arrayToHash);


### PR DESCRIPTION
Ne pas oublier d'ajouter effectivement la valeur dans les fichiers wp-config.php

Par exemple:
```
define('POSTFINANCE_SHA_IN', 'le_sign_key_approprié');
```

La valeur est différente en prod qu'en test.