### PR TITLE
 CO-2267 : Controller Wordpress qui crée des partenaires ( WP-14 +  WP-9 +  WP-13 )

### DIFF
--- a/cf7-pf_oli_klay/cf7-pf_oli.php
+++ b/cf7-pf_oli_klay/cf7-pf_oli.php
@@ -145,6 +145,8 @@ class donationForm {
 
         add_shortcode('donation-form', array($this, 'shortcode'));
 
+        add_shortcode('donation-confirmation', array($this, 'shortcode_confirmation'));
+
 
         // load styles
         wp_enqueue_style('donation-form', plugin_dir_url(__FILE__) . '/assets/stylesheets/screen.css', array(), null);
@@ -343,6 +345,187 @@ class donationForm {
         <?php
     }
 
+    /**
+     * Generate shortcode for dealing with a PostFinance transaction.
+     *
+     * @return string
+     */
+    public function shortcode_confirmation($atts, $content) {
+
+        $atts = shortcode_atts(array(), $atts);
+
+        ob_start();
+
+        if ($_SERVER['HTTP_HOST'] == TEST_SERVER) {
+
+//        $debug = false;
+            $debug = true;
+            if ($debug) {
+                print_r($_GET);
+            }
+        } else {
+
+            $debug = false;
+        }
+
+        $table_name = $wpdb->prefix . "donation_to_odoo";
+        global $wpdb;
+
+        if (isset($_GET['COMPLUS']) AND strlen($_GET['COMPLUS']) == 36) {
+
+            error_log('Process to export to Odoo is running now... ');
+
+            $complus = filter_var($_GET['COMPLUS'], FILTER_SANITIZE_STRING);
+
+
+            $time_transaction = $wpdb->get_var(
+                $wpdb->prepare(
+                    "SELECT time FROM " . $table_name . " "
+                    . "WHERE transaction_id='%s' "
+                    . "AND odoo_status = 'submit_to_pf' "
+                    . "LIMIT 1", $complus));
+
+            // return from Postfinance should occur within 5 minutes, otherwise we ignore the db update.
+            if ($debug) {
+                $additional_time = 1500000;
+            } else {
+                $additional_time = 72000;
+            }
+            if (time() < (strtotime($time_transaction) + $additional_time )) {
+
+                if ($debug) {
+                    echo 'continue donation process...';
+                }
+                error_log('Update transaction with parameters received from Postfinance');
+
+                $wpdb->update($table_name, array(
+                    'pf_pm' => $_GET['PM'],
+                    'pf_payid' => $_GET['PAYID'],
+                    'pf_brand' => $_GET['BRAND'],
+                    'pf_raw' => json_encode($_GET),
+                    'ip_address' => $_GET['IP'],
+                    'odoo_status' => 'received_from_pf'
+                ), array('transaction_id' => $complus,
+                        'odoo_complete_time' => NULL)
+                );
+
+                unset($_SESSION['transaction']);
+
+//        } else {
+//            wp_die('Request timeout. ');
+            }
+        }
+
+
+        if(isset($_GET) OR isset($_POST)) {
+
+            error_log('Looking for payments to export...');
+
+            $results = $wpdb->get_results("SELECT * FROM " . $table_name . " WHERE odoo_status = 'received_from_pf' ");
+
+            if ($debug) {
+                print_r($results);
+            }
+
+            try {
+                if (sizeof($results) >= 1) {
+
+                    $odoo = new CompassionOdooConnector($debug);
+
+                    foreach ($results as $result) {
+
+                        unset($search_partner);
+                        unset($partner);
+                        $partner_id = '';
+
+                        try {
+
+                            if ($result->email != '' AND strlen(trim($result->email))>=5 AND $result->child_id != '' AND strlen($result->child_id)>=8) {
+
+                                $search = $odoo->searchContractByPartnerEmailChildCode($result->email, $result->child_id);
+                                $partner_id = $search[0]['partner_id'][0];
+                            }
+
+                            if (empty($partner_id)) {
+                                error_log('Partner ID not found with email and child_id');
+                                throw new Exception('foo');
+                            }
+
+                        } catch (Exception $e) {
+
+                            if ($result->last_name != '' AND strlen(trim($result->last_name))>=3 AND $result->child_id != '' AND strlen($result->child_id)>=8) {
+
+                                $search = $odoo->searchContractByPartnerLastNameChildCode($result->last_name, $result->child_id);
+                                if (!empty($search)) {
+                                    $partner_id = $search[0]['partner_id'][0];
+
+                                    if($debug) {
+                                        echo ' ###'.$partner_id.'### ';
+                                    }
+                                }
+                            }
+
+                            if(empty($partner_id)) {
+
+                                error_log('Searching partner with email, last_name, first_name, ...');
+                                $search = $odoo->searchPartnerByEmailNameCity($result->email, $result->last_name, $result->first_name, $result->city);
+                                if($debug) {
+                                    print_r($search);
+                                }
+                                if (!empty($search)) {
+                                    $partner_id = $search[0];
+                                    if($debug) {
+                                        echo ' ##'.$partner_id.'## ';
+                                    }
+                                }
+                            }
+
+                            if(empty($partner_id)) {
+
+                                error_log('Let\'s create a partner');
+                                $partner_id = $odoo->createPartner(
+                                    $result->last_name, $result->first_name, $result->street, $result->zipcode, $result->city, $result->email, $result->country, $result->language);
+                            }
+                        }
+
+                        if (!empty($partner_id)) {
+
+//                            $invoice_id = $odoo->createInvoiceWithObjects(
+//                                    $partner_id, date('Y-m-d H:i:s'), 'survie', '12.34', 'CHF', 'fund', $child_code, 'CreditCard', '1234567890', 'Mastercard');
+
+                            $invoice_id = $odoo->createInvoiceWithObjects(
+                                $partner_id, $result->orderid, $result->amount, $result->fund, $result->child_id,
+                                $result->pf_pm, $result->pf_payid, $result->pf_brand, $result->utm_source,
+                                $result->utm_medium, $result->utm_campaign);
+
+                            if($debug) {
+                                print_r($invoice_id);
+                            }
+                            if (!empty($invoice_id)) {
+
+                                $wpdb->update($table_name, array(
+                                    'odoo_status' => 'invoiced',
+                                    'odoo_invoice_id' => $invoice_id,
+                                    'odoo_complete_time' => date('Y-m-d H:i:s'),
+                                ), array('transaction_id' => $result->transaction_id)
+                                );
+                            }
+                        }
+                    }
+                }
+            } catch (Exception $ex) {
+
+                echo 'Error occured. Please try again. ';
+                if ($debug) {
+                    print_r($ex);
+                }
+            }
+        }
+
+        $content = ob_get_contents();
+        ob_end_clean();
+        return $content;
+    }
 }
 
 new donationForm();

--- a/cf7-pf_oli_klay/cf7-pf_oli.php
+++ b/cf7-pf_oli_klay/cf7-pf_oli.php
@@ -363,16 +363,8 @@ class Compassion_Donation_Form {
 
         ob_start();
 
-        if ($_SERVER['HTTP_HOST'] == TEST_SERVER) {
-
-//        $debug = false;
-            $debug = true;
-            if ($debug) {
-                print_r($_GET);
-            }
-        } else {
-
-            $debug = false;
+        if (WP_DEBUG) {
+            print_r($_GET);
         }
 
         global $wpdb;
@@ -410,14 +402,14 @@ class Compassion_Donation_Form {
 
             $results = $wpdb->get_results("SELECT * FROM " . $table_name . " WHERE odoo_status = '" . self::RECEIVED_FROM_PF . "'");
 
-            if ($debug) {
+            if (WP_DEBUG) {
                 print_r($results);
             }
 
             try {
                 if (sizeof($results) >= 1) {
 
-                    $odoo = new CompassionOdooConnector($debug);
+                    $odoo = new CompassionOdooConnector();
 
                     foreach ($results as $result) {
 
@@ -446,7 +438,7 @@ class Compassion_Donation_Form {
                                 if (!empty($search)) {
                                     $partner_id = $search[0]['partner_id'][0];
 
-                                    if($debug) {
+                                    if(WP_DEBUG) {
                                         echo ' ###'.$partner_id.'### ';
                                     }
                                 }
@@ -456,12 +448,12 @@ class Compassion_Donation_Form {
 
                                 error_log('Searching partner with email, last_name, first_name, ...');
                                 $search = $odoo->searchPartnerByEmailNameCity($result->email, $result->last_name, $result->first_name, $result->city);
-                                if($debug) {
+                                if(WP_DEBUG) {
                                     print_r($search);
                                 }
                                 if (!empty($search)) {
                                     $partner_id = $search[0];
-                                    if($debug) {
+                                    if(WP_DEBUG) {
                                         echo ' ##'.$partner_id.'## ';
                                     }
                                 }
@@ -485,7 +477,7 @@ class Compassion_Donation_Form {
                                 $result->pf_pm, $result->pf_payid, $result->pf_brand, $result->utm_source,
                                 $result->utm_medium, $result->utm_campaign);
 
-                            if($debug) {
+                            if(WP_DEBUG) {
                                 print_r($invoice_id);
                             }
                             if (!empty($invoice_id)) {
@@ -503,10 +495,11 @@ class Compassion_Donation_Form {
             } catch (Exception $ex) {
 
                 echo 'Error occured. Please try again. ';
-                if ($debug) {
+                if (WP_DEBUG) {
                     print_r($ex);
                 }
             }
+
         }
 
         $content = ob_get_contents();

--- a/cf7-pf_oli_klay/cf7-pf_oli.php
+++ b/cf7-pf_oli_klay/cf7-pf_oli.php
@@ -384,43 +384,23 @@ class Compassion_Donation_Form {
 
             $complus = filter_var($_GET['COMPLUS'], FILTER_SANITIZE_STRING);
 
-
-            $time_transaction = $wpdb->get_var(
-                $wpdb->prepare(
-                    "SELECT time FROM " . $table_name . " "
-                    . "WHERE transaction_id='%s' "
-                    . "AND odoo_status = '" . self::SUBMITTED_FROM_PF . "'"
-                    . "LIMIT 1", $complus));
-
-            // return from Postfinance should occur within 5 minutes, otherwise we ignore the db update.
             if ($debug) {
-                $additional_time = 1500000;
-            } else {
-                $additional_time = 72000;
+                echo 'continue donation process...';
             }
-            if (time() < (strtotime($time_transaction) + $additional_time )) {
+            error_log('Update transaction with parameters received from Postfinance');
 
-                if ($debug) {
-                    echo 'continue donation process...';
-                }
-                error_log('Update transaction with parameters received from Postfinance');
+            $wpdb->update($table_name, array(
+                'pf_pm' => $_GET['PM'],
+                'pf_payid' => $_GET['PAYID'],
+                'pf_brand' => $_GET['BRAND'],
+                'pf_raw' => json_encode($_GET),
+                'ip_address' => $_GET['IP'],
+                'odoo_status' => self::RECEIVED_FROM_PF
+            ), array('transaction_id' => $complus,
+                    'odoo_complete_time' => NULL)
+            );
 
-                $wpdb->update($table_name, array(
-                    'pf_pm' => $_GET['PM'],
-                    'pf_payid' => $_GET['PAYID'],
-                    'pf_brand' => $_GET['BRAND'],
-                    'pf_raw' => json_encode($_GET),
-                    'ip_address' => $_GET['IP'],
-                    'odoo_status' => self::RECEIVED_FROM_PF
-                ), array('transaction_id' => $complus,
-                        'odoo_complete_time' => NULL)
-                );
-
-                unset($_SESSION['transaction']);
-
-//        } else {
-//            wp_die('Request timeout. ');
-            }
+            unset($_SESSION['transaction']);
         }
 
 

--- a/cf7-pf_oli_klay/cf7-pf_oli.php
+++ b/cf7-pf_oli_klay/cf7-pf_oli.php
@@ -247,7 +247,7 @@ class Compassion_Donation_Form {
         $session_data = $data;
         $my_current_lang = apply_filters('wpml_current_language', NULL);
         if ($my_current_lang == 'fr') {
-            $lang = 'fr_FR';
+            $lang = 'fr_CH';
         } elseif ($my_current_lang == 'de') {
             $lang = 'de_DE';
         } elseif ($my_current_lang == 'it') {

--- a/compassion-letters/files/pdf/.gitignore
+++ b/compassion-letters/files/pdf/.gitignore
@@ -1,4 +1,0 @@
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore

--- a/compassion-letters/files/thumb/.gitignore
+++ b/compassion-letters/files/thumb/.gitignore
@@ -1,4 +1,0 @@
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore

--- a/compassion-letters/files/uploads/.gitignore
+++ b/compassion-letters/files/uploads/.gitignore
@@ -1,4 +1,0 @@
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore

--- a/compassion-odoo/compassion-odoo-connector.php
+++ b/compassion-odoo/compassion-odoo-connector.php
@@ -357,6 +357,13 @@ class CompassionOdooConnector {
         ));
     }
 
+    /**
+     * Send the raw information about a donation to Odoo.
+     */
+    public function send_donation_info($donnation_infos) {
+        return $this->call_method('account.invoice', 'process_wp_confirmed_donation', array($donnation_infos));
+    }
+
      /**
      * Generic function to call any method on Odoo
      * @param $model   string: the name of odoo model

--- a/compassion-odoo/compassion-odoo-connector.php
+++ b/compassion-odoo/compassion-odoo-connector.php
@@ -20,16 +20,10 @@ class CompassionOdooConnector {
     private $odoo_db = ODOO_DB;
     private $odoo_user = ODOO_USER;
     private $odoo_password = ODOO_PASSWORD;
-    private $debug;
     private $uid;
     private $models;
     
     public function __construct() {
-        if ($_SERVER['HTTP_HOST'] == TEST_SERVER) {
-            $this->debug = true;
-        } else {
-            $this->debug = false;
-        }
         $common = ripcord::client($this->odoo_host . '/xmlrpc/2/common');
         $transport = new ripcord_Transport_Stream(array(
             'timeout' => 10 // in seconds.


### PR DESCRIPTION
Pour utiliser ces changements, il faut modifier la page confirmation-don depuis wp-admin afin qu'elle fasse appel au shortcode [donation-confirmation] et qu'elle n'utilise plus le template (modèle) "Don vers Odoo". Ne pas oublier de le faire également pour toutes les traductions.

Cette pull request nécessite auparavent le merge de CompassionCH/compassion-switzerland#788 et CompassionCH/compassion-modules#931.

![capture d ecran de 2019-02-20 12-01-14](https://user-images.githubusercontent.com/25900023/53087372-475f9380-3507-11e9-8c61-d650e1f9ba31.png)
![capture d ecran de 2019-02-20 12-00-58](https://user-images.githubusercontent.com/25900023/53087377-4a5a8400-3507-11e9-9fa7-919b9c2f42a8.png)
![capture d ecran de 2019-02-20 12-30-09](https://user-images.githubusercontent.com/25900023/53088888-50526400-350b-11e9-9897-6e0c4afcb3d5.png)


Une fois ce changement effectué en prod, il faut créer une issue pour supprimer le template-don-odoo du thème ainsi que les méthodes qui ne sont plus utilisées du plugin compassion-odoo.
