### PR TITLE
WP-41 Decrease max image size (server-side, 2MB => 512KB)

### DIFF
--- a/compassion-letters/compassion-letters.php
+++ b/compassion-letters/compassion-letters.php
@@ -141,7 +141,7 @@ class CompassionLetters
     private function maybe_resize_image($image_path) {
         $image = new Imagick($image_path);
         $imageLength = $image->getImageLength();
-        $maxImageLength = 2 * 1024 * 1024.0;
+        $maxImageLength = 0.5 * 1024 * 1024.0;
         if($imageLength <= $maxImageLength) {
             return;
         }


### PR DESCRIPTION
Note, the javascript still has the limit of 10MB from commit 52739f5