### PR TITLE
WP-45 image upload fix

### DIFF
--- a/compassion-letters/assets/js/main.js
+++ b/compassion-letters/assets/js/main.js
@@ -15,7 +15,7 @@ jQuery(document).ready(function($) {
     $.validator.addMethod(
         "maxfilesize",
         function (value, element) {
-            return this.optional(element) || (element.files && element.files[0] && element.files[0].size < 1024 * 1024 * 2 && (element.files[0].type == 'image/png' || element.files[0].type == 'image/jpg' || element.files[0].type == 'image/jpeg'));
+            return this.optional(element) || (element.files && element.files[0] && element.files[0].size < 1024 * 1024 * 10.5 && (element.files[0].type == 'image/png' || element.files[0].type == 'image/jpg' || element.files[0].type == 'image/jpeg'));
         },
         'Bitte beachten Sie die Vorgaben für den Bild-Upload/Merci de respecter les indications pour l\'envoi d\'une photo'
     );

--- a/compassion-letters/compassion-letters.php
+++ b/compassion-letters/compassion-letters.php
@@ -156,15 +156,15 @@ class CompassionLetters
      */
     private function maybe_resize_image($image_path) {
         $image = new Imagick($image_path);
-	
-	$write = False;
-	if($image->getImageFormat() != 'jpeg'){
-	    $write = True;
+
+        $write = False;
+        if($image->getImageFormat() != 'jpeg'){
+            $write = True;
             // PNGs may contain transparency
-	    $image->setImageBackgroundColor(new ImagickPixel('white'));
+            $image->setImageBackgroundColor(new ImagickPixel('white'));
             // Write format
-	    $image->setImageFormat('jpeg');
-	}
+            $image->setImageFormat('jpeg');
+        }
 
         $imageLength = $image->getImageLength();
         $maxImageLength = 0.5 * 1024 * 1024.0;


### PR DESCRIPTION
- Sur le site il est écrit "Max 10MB" mais la limite dans JavaScript était encore à 1MB
- Odoo à des problèmes avec les PNGs, je profite de la méthode qui resize l'image pour convertir les PNGs en JPG.

Il faudrait accepter cette PR sur Devel pour faire encore un test sur le site de devcomp.site. Puis merger sur Master.