### PR TITLE
WP-46 write&pray add an age limit and sponsor can contribute

### DIFF
--- a/child-sponsor/templates/email/user-new-sponsor.php
+++ b/child-sponsor/templates/email/user-new-sponsor.php
@@ -55,7 +55,7 @@
         /* Styling your links has become much simpler with the new Yahoo.  In fact, it falls in line with the main credo of styling in email, bring your styles inline.  Your link colors will be uniform across clients when brought inline.
         Bring inline: Yes. */
         a.lsv-box{padding:5px 8px;margin:10px 0 10px 10px; background-color:red; color:white !important;}
-        
+
         a {color:#005eb8; text-decoration: underline}
 
         ul li {
@@ -152,7 +152,7 @@
 
             <h1 style="text-align: center; padding: 25px 0;">Un grand MERCI pour votre engagement</h1>
 			<?php $child_meta = get_child_meta($session_data['childID']);?>
-			
+
 			<div style="padding: 0 30px;">
 			 <p>
 			<?php echo ($session_data['salutation'] == 'Herr') ? __('Lieber', 'compassion-letters') : __('Liebe', 'compassion-letters');?> <?php  $salutation = apply_filters( 'wpml_object_id', $session_data['salutation'], 'post', TRUE);
@@ -160,17 +160,17 @@
 			Bienvenue dans la grande famille de Compassion. Vous avez décidé de parrainer <?php echo $child_meta['name']; ?>. Merci de vous engager à changer la vie de cet enfant! C’est un jour de fête pour chaque enfant et sa famille lorsque les collaborateurs d’un centre d’accueil l’informent qu’un parrain s’intéresse à lui et a choisi de le soutenir. Vous êtes aujourd’hui la source d’une très grande joie! Au nom de <?php echo $child_meta['name']; ?>, MERCI !
 			 </p>
 			 <p> Vous recevrez dans les tous prochains jours toutes les informations concernant votre parrainage, par poste. Pour cela, merci de bien vérifier vos données ainsi que votre adresse postale.</p>
-			
-			
+
+
 			<h4> Vous nous avez transmis les informations suivantes:</h4>
-				 						
+
           <div style="padding: 0 30px;">
-	          
+
 	          	<p>Je prends en charge le parrainage de:  <strong><?php echo $child_meta['name']; ?></strong></p>
 
-	          
+
                 <h3>Enfant</h3>
-              
+
                 <ul>
                     <li><?php _e('Name', 'child-sponsor-lang'); ?>: <?php echo $child_meta['name']; ?></li>
                     <li><?php _e('Land','child-sponsor-lang'); ?>: <?php echo $child_meta['country']; ?></li>
@@ -197,49 +197,50 @@
                     <li><?php _e('Beruf', 'child-sponsor-lang'); ?>: <?php echo $session_data['Beruf']; ?></li>
 
                 </ul>
-				
-				    <?php    $wapr = isset($_SESSION['utm_source']) && $_SESSION['utm_source']=='wrpr';?> 
 
+				<?php
+        $wapr = isset($_SESSION['utm_source']) && $_SESSION['utm_source']=='wrpr';
+        if ($wapr) {
+            echo "<h3>Parrainage Write & Pray</h3>";
+            if (isset($session_data['writepray'])) {
+                if ($session_data['writepray'] == 'WRPR'){
+                  echo _e('Ich engagiere mich für mein Patenkind zu beten und ihm regelmässsig zu schreiben.  Ich habe verstanden, dass eine andere Person die Finanzierung dieser Patenschaft übernimmt und ich gegenüber dem Kind der/die offizielle Pate/Patin bin.', 'child-sponsor-lang');
+                } else if($session_data['writepray'] == 'WRPR+DON'){
+                  echo _e('Je m\'engage à [...] et je peux contribuer mensuellement à hauteur de : ', 'child-sponsor-lang');
+                  echo '<b>' . $session_data['writepray-contribution'] . 'CHF</b>';
+                }
+            }
+		   	} else {
+        ?>
 
-                <?php if ($wapr) { ?> 
-                
-               <h3>Parrainage Write & Pray</h3>
-               
-                 <?php if (isset($session_data['writepray'])) {
-	          echo _e('JA', 'child-sponsor-lang'); 
-	          } else {echo _e('NEIN', 'child-sponsor-lang');}
-           ?> 
-		   	
-		   	<?php } else { ?>
-				
 				<h3>Parrainage plus</h3>
 				  <?php if (isset($session_data['patenschaftplus'])) {
-				  		echo _e('JA', 'child-sponsor-lang'); 
+				  		echo _e('JA', 'child-sponsor-lang');
 				  		} else {echo _e('NEIN', 'child-sponsor-lang');}
-				  ?> 
+				  ?>
 
 				<h3>Méthode de paiement</h3>
-				
+
 					<?php
-                        $zahlung = ($session_data['zahlungsweise']);	                        
+                        $zahlung = ($session_data['zahlungsweise']);
 	                        if ($zahlung == 'dauerauftrag'){
 		                        echo _e('Monatlicher Dauerauftrag', 'child-sponsor-lang');
-	                        } 
+	                        }
 	                        elseif ($zahlung == 'lsv'){
 		                        echo _e('Direct Debit - LSV', 'child-sponsor-lang');
 		                        echo '&nbsp;<a class="lsv-box" href="https://www.compassion.ch/wp-content/uploads/documents_compassion/Formulaire_LSV_DD_FR.pdf">Téléchargez le formulaire de demande LSV</a>';
 	                        }
-                                                 
+
                         ?>
-                     	    <?php } ?>   
-                        
+                     	    <?php } ?>
+
                 <h3>Correspondance avec <?php echo $child_meta['name']; ?></h3>
-                
+
                 <?php
 	            if(!empty($session_data['language'])) {
 				foreach($session_data['language'] as $check) {
 				echo'<ul>';
-				echo  '<li>';			
+				echo  '<li>';
 				switch ($check) {
 
 				case 'französich':
@@ -249,15 +250,15 @@
 				case 'italienisch':
 				echo _e('Italienisch','child-sponsor-lang');
 				break;
-				
+
 				case 'spanisch':
 				echo _e('Spanisch','child-sponsor-lang');
 				break;
-				
+
 				case 'englisch':
 				echo _e('Englisch','child-sponsor-lang');
 				break;
-				
+
 				case 'portugiesisch':
 				echo _e('Portugiesisch','child-sponsor-lang');
 				break;
@@ -266,7 +267,7 @@
 				}
 				}
 				?>
-                
+
                 <h3>Votre réponse à la question : Comment avez-vous connu Compassion ?</h3>
                 <ul>
                    <li>
@@ -279,22 +280,22 @@
                            echo _e($session_data['consumer_source_text'], 'child-sponsor-lang');
                        }?>
                    </li>
-                </ul> 
+                </ul>
 
 				<h3>Envoyez-moi des informations sur les autres possibilités d'engagement au profit des enfants démunis.</h3>
 						<?php if (isset($session_data['mithelfen'])) {
-				  		echo _e('JA', 'child-sponsor-lang'); 
+				  		echo _e('JA', 'child-sponsor-lang');
 				  		} else {echo _e('NEIN', 'child-sponsor-lang');}
-				  ?> 
+				  ?>
 
                 <hr>
-                
+
                <p>Si vous avez des questions au sujet de votre parrainage, nous restons volontiers à votre disposition: Téléphone: 024 434 21 24 (lundi à vendredi de 8h00 à 16h00) – Adresse e-mail: info@compassion.ch</p>
 
 			   <p>Merci du fond du cœur d’avoir choisi d’investir dans la vie d’un enfant. Michelle aux Philippines a grandi dans un quartier pauvre où régnait trafic et consommation de drogue et prostitution. Parrainée, elle a pu aller à l’école, suivre des études. Aujourd’hui, elle dirige l’ONG qu’elle a créée et vient en aide aux femmes victimes d’esclavage moderne. Votre parrainage va transformer une vie durablement.<br/><br/>
 				   Très cordialement,<br/>Carole Rochat pour l’équipe de Compassion Suisse</p>
             </div>
-            
+
             <p style="text-align: center;padding-top:30px"><img src="<?php echo get_template_directory_uri(); ?>/assets/img/compassion-logo-dark-fr.png" width="242" height="93" alt="" /><p>
 
 

--- a/child-sponsor/templates/email_de/user-new-sponsor.php
+++ b/child-sponsor/templates/email_de/user-new-sponsor.php
@@ -150,22 +150,22 @@
 
             <h1 style="text-align: center; padding: 25px 0;">Ein grosses MERCI für dein Engagement	</h1>
 			<?php $child_meta = get_child_meta($session_data['childID']);?>
-			
+
 			<div style="padding: 0 30px;">
 			 <p>
 			<?php echo ($session_data['salutation'] == 'Herr') ? __('Lieber', 'compassion-letters') : __('Liebe', 'compassion-letters');?> <?php echo $session_data['first_name']; ?> <br /><br />
 			Du hast dich entschieden, <?php echo $child_meta['name']; ?> durch eine Patenschaft zu unterstützen. Vielen Dank, dass mit deiner Hilfe das Leben dieses Kindes verändert wird! Kannst du dir die Riesenfreude vorstellen, wenn unsere Mitarbeitenden vor Ort dem Kind mitteilen können, dass es jetzt auf der anderen Seite der Welt eine Patin oder einen Paten hat? DANKE im Namen von <?php echo $child_meta['name']; ?> und seiner/ihrer Familie!
 			 </p>
 			 <p>Du wirst bald per Post alle Informationen über deine Patenschaft erhalten. Überprüfe dazu bitte deine Angaben:</p>
-			
-				 						
+
+
           <div style="padding: 0 30px;">
-	          
+
 	          	<p>Ich übernehme die Patenschaft für: <strong><?php echo $child_meta['name']; ?></strong></p>
 
-	          
+
                 <h3>Patenkind</h3>
-              
+
                 <ul>
                     <li><?php _e('Name', 'child-sponsor-lang'); ?>: <?php echo $child_meta['name']; ?></li>
                     <li><?php _e('Land','child-sponsor-lang'); ?>: <?php echo $child_meta['country']; ?></li>
@@ -192,45 +192,47 @@
                     <li><?php _e('Beruf', 'child-sponsor-lang'); ?>: <?php echo $session_data['Beruf']; ?></li>
 
                 </ul>
-                
-                <!--              Writeandpraystuff  -->
-                
-				<?php    $wapr = isset($_SESSION['utm_source']) && $_SESSION['utm_source']=='wrpr';?> 
 
-                <?php if ($wapr) { ?> 
-				<h3>Patenschaft Write & Pray</h3>
-               
-                 <?php if (isset($session_data['writepray'])) {
-	          echo _e('JA', 'child-sponsor-lang'); 
-	          } else {echo _e('NEIN', 'child-sponsor-lang');}
-           		?> 
-		   	
-		   	<?php } else { ?>
+        <!--              Writeandpraystuff  -->
+        <?php
+        $wapr = isset($_SESSION['utm_source']) && $_SESSION['utm_source']=='wrpr';
+        if ($wapr) {
+            echo "<h3>Patenschaft Write & Pray</h3>";
+            if (isset($session_data['writepray'])) {
+                if ($session_data['writepray'] == 'WRPR'){
+                  echo _e('Ich engagiere mich für mein Patenkind zu beten und ihm regelmässsig zu schreiben.  Ich habe verstanden, dass eine andere Person die Finanzierung dieser Patenschaft übernimmt und ich gegenüber dem Kind der/die offizielle Pate/Patin bin.', 'child-sponsor-lang');
+                } else if($session_data['writepray'] == 'WRPR+DON'){
+                  echo _e('Je m\'engage à [...] et je peux contribuer mensuellement à hauteur de : ', 'child-sponsor-lang');
+                  echo '<b>' . $session_data['writepray-contribution'] . 'CHF</b>';
+                }
+            }
+		   	} else {
+        ?>
 		   	<!--              END Writeandpraystuff  -->
 
 				<h3>Patenschaft Plus</h3>
 				  <?php if (isset($session_data['patenschaftplus'])) {
-				  		echo _e('JA', 'child-sponsor-lang'); 
+				  		echo _e('JA', 'child-sponsor-lang');
 				  		} else {echo _e('NEIN', 'child-sponsor-lang');}
-				  ?> 
+				  ?>
 
 				<h3>Zahlungsweise</h3>
-				
+
 					<?php
-                        $zahlung = ($session_data['zahlungsweise']);	                        
+                        $zahlung = ($session_data['zahlungsweise']);
 	                        if ($zahlung == 'dauerauftrag'){
 		                        echo _e('Monatlicher Dauerauftrag', 'child-sponsor-lang');
-	                        } 
+	                        }
 	                        elseif ($zahlung == 'lsv'){
 		                        echo _e('Direct Debit - LSV', 'child-sponsor-lang');
 		                        echo '&nbsp;<a class="lsv-box" href="https://www.compassion.ch/wp-content/uploads/documents_compassion/Formulaire_LSV_DD_DE.pdf">LSV Formular aufladen</a>';
 	                        }
-                                                 
+
                         ?>
-                    <?php } ?>   
+                    <?php } ?>
 
                 <h3>Korrespondenz mit <?php echo $child_meta['name']; ?></h3>
-                
+
                      <?php
 	            if(!empty($session_data['language'])) {
 				foreach($session_data['language'] as $check) {
@@ -245,15 +247,15 @@
 				case 'italienisch':
 				echo _e('Italienisch','child-sponsor-lang');
 				break;
-				
+
 				case 'spanisch':
 				echo _e('Spanisch','child-sponsor-lang');
 				break;
-				
+
 				case 'englisch':
 				echo _e('Englisch','child-sponsor-lang');
 				break;
-				
+
 				case 'portugiesisch':
 				echo _e('Portugiesisch','child-sponsor-lang');
 				break;
@@ -275,22 +277,22 @@
                         }?>
                     </li>
                 </ul>
-                
-                
+
+
                 <h3>Sende mir mehr Informationen, wie ich mich für Kinder in Not einsetzen kann</h3>
 						<?php if (isset($session_data['mithelfen'])) {
-				  		echo _e('JA', 'child-sponsor-lang'); 
+				  		echo _e('JA', 'child-sponsor-lang');
 				  		} else {echo _e('NEIN', 'child-sponsor-lang');}
-				  ?> 
-				  
+				  ?>
+
 				    <hr>
-                
+
                <p>Wenn du noch Fragen zu deiner Patenschaft hast, melde dich gerne bei uns: Tel : 031 552 21 21 (Montag bis Freitag von 8.00-16.00 Uhr) - Email: info@compassion.ch</p>
 
 			   <p>Herzlich willkommen in der grossen internationalen Familie von Compassion!<br/>
 				   Freundliche Grüsse,<br/>Carole Rochat und das Compassion Schweiz Team.</p>
             </div>
-            
+
             <p style="text-align: center;padding-top:30px"><img src="<?php echo get_template_directory_uri(); ?>/assets/img/compassion-logo-dark-de.png" width="242" height="93" alt="" /><p>
 
 

--- a/child-sponsor/templates/email_it/user-new-sponsor.php
+++ b/child-sponsor/templates/email_it/user-new-sponsor.php
@@ -55,7 +55,7 @@
         /* Styling your links has become much simpler with the new Yahoo.  In fact, it falls in line with the main credo of styling in email, bring your styles inline.  Your link colors will be uniform across clients when brought inline.
         Bring inline: Yes. */
         a.lsv-box{padding:5px 8px;margin:10px 0 10px 10px; background-color:red; color:white !important;}
-        
+
         a {color:#005eb8; text-decoration: underline}
 
         ul li {
@@ -152,7 +152,7 @@
 
             <h1 style="text-align: center; padding: 25px 0;">Un grande GRAZIE per il vostro impegno</h1>
 			<?php $child_meta = get_child_meta($session_data['childID']);?>
-			
+
 			<div style="padding: 0 30px;">
 			 <p>
 			<?php echo ($session_data['salutation'] == 'Herr') ? __('Lieber', 'compassion-letters') : __('Liebe', 'compassion-letters');?> <?php  $salutation = apply_filters( 'wpml_object_id', $session_data['salutation'], 'post', TRUE);
@@ -160,17 +160,17 @@
 			Avete deciso di sostenere <?php echo $child_meta['name']; ?>. Grazie del vostro impegno nel cambiare la vita di questo bambino! È difficile immaginare la gioia che i bambini sentono nel momento in cui i collaboratori dei Centri Compassion gli annunciano che dall'altra parte del globo c'è un sostenitore che si prende cura di loro. Oggi voi siete fonte di grande gioia! A nome di <?php echo $child_meta['name']; ?>, GRAZIE!
 			 </p>
 			 <p> Presto riceverete per posta tutte le informazioni per il vostro sostegno. Per questo, grazie di verificare i vostri dati e il vostro indirizzo postale.</p>
-			
-			
+
+
 			<h4> Avete trasmetto le informazioni seguenti:</h4>
-				 						
+
           <div style="padding: 0 30px;">
-	          
+
 	          	<p>Prendo l'incarico di sostenere:<strong> <?php echo $child_meta['name']; ?></strong></p>
 
-	          
+
                 <h3>Bambino</h3>
-              
+
                 <ul>
                     <li><?php _e('Name', 'child-sponsor-lang'); ?>: <?php echo $child_meta['name']; ?></li>
                     <li><?php _e('Land','child-sponsor-lang'); ?>: <?php echo $child_meta['country']; ?></li>
@@ -197,43 +197,46 @@
                     <li><?php _e('Beruf', 'child-sponsor-lang'); ?>: <?php echo $session_data['Beruf']; ?></li>
 
                 </ul>
-                   <!--              Writeandpraystuff  -->
-                
-				<?php    $wapr = isset($_SESSION['utm_source']) && $_SESSION['utm_source']=='wrpr';?> 
 
-                <?php if ($wapr) { ?> 
-				<h3>Sostegno Write & Pray</h3>
-               
-                 <?php if (isset($session_data['writepray'])) {
-	          echo _e('JA', 'child-sponsor-lang'); 
-	          } else {echo _e('NEIN', 'child-sponsor-lang');}
-           		?> 
-		   	
-		   	<?php } else { ?>
+        <!--              Writeandpraystuff  -->
+        <?php
+        $wapr = isset($_SESSION['utm_source']) && $_SESSION['utm_source']=='wrpr';
+        if ($wapr) {
+            echo "<h3>Sostegno Write & Pray</h3>";
+            if (isset($session_data['writepray'])) {
+                if ($session_data['writepray'] == 'WRPR'){
+                  echo _e('Ich engagiere mich für mein Patenkind zu beten und ihm regelmässsig zu schreiben.  Ich habe verstanden, dass eine andere Person die Finanzierung dieser Patenschaft übernimmt und ich gegenüber dem Kind der/die offizielle Pate/Patin bin.', 'child-sponsor-lang');
+                } else if($session_data['writepray'] == 'WRPR+DON'){
+                  echo _e('Je m\'engage à [...] et je peux contribuer mensuellement à hauteur de : ', 'child-sponsor-lang');
+                  echo '<b>' . $session_data['writepray-contribution'] . 'CHF</b>';
+                }
+            }
+		   	} else {
+        ?>
 		   	<!--              END Writeandpraystuff  -->
 
 				<h3>Sostegno plus</h3>
 				  <?php if (isset($session_data['patenschaftplus'])) {
-				  		echo _e('JA', 'child-sponsor-lang'); 
+				  		echo _e('JA', 'child-sponsor-lang');
 				  		} else {echo _e('NEIN', 'child-sponsor-lang');}
-				  ?> 
+				  ?>
 
 				<h3>Metodo di pagamento</h3>
-				
+
 					<?php
-                        $zahlung = ($session_data['zahlungsweise']);	                        
+                        $zahlung = ($session_data['zahlungsweise']);
 	                        if ($zahlung == 'dauerauftrag'){
 		                        echo _e('Monatlicher Dauerauftrag', 'child-sponsor-lang');
-	                        } 
+	                        }
 	                        elseif ($zahlung == 'lsv'){
 		                        echo _e('Direct Debit - LSV', 'child-sponsor-lang');
 		                        echo '&nbsp;<a class="lsv-box" href="https://www.compassion.ch/wp-content/uploads/documents_compassion/Formulaire_LSV_DD_IT.pdf">' . _e("Téléchargez le formulaire de demande LSV", "child-sponsor-lang") . '</a>';
 	                        }
-                                                 
+
                         ?>
-                      <?php } ?>          
+                      <?php } ?>
                 <h3>Scambio di lettere con <?php echo $child_meta['name']; ?></h3>
-                
+
                    <?php
 	            if(!empty($session_data['language'])) {
 				foreach($session_data['language'] as $check) {
@@ -248,15 +251,15 @@
 				case 'italienisch':
 				echo _e('Italienisch','child-sponsor-lang');
 				break;
-				
+
 				case 'spanisch':
 				echo _e('Spanisch','child-sponsor-lang');
 				break;
-				
+
 				case 'englisch':
 				echo _e('Englisch','child-sponsor-lang');
 				break;
-				
+
 				case 'portugiesisch':
 				echo _e('Portugiesisch','child-sponsor-lang');
 				break;
@@ -265,7 +268,7 @@
 				}
 				}
 				?>
-				
+
 				<h3>La vostra risposta alla questione: Come ha conosciuto Compassion?</h3>
                <ul>
                    <li>
@@ -278,16 +281,16 @@
                            echo _e($session_data['consumer_source_text'], 'child-sponsor-lang');
                        }?>
                    </li>
-                </ul> 
-				
+                </ul>
+
 				<h3>Inviatemi maggiori informazioni su come posso aiutare i bambini nel bisogno.</h3>
 						<?php if (isset($session_data['mithelfen'])) {
-				  		echo _e('JA', 'child-sponsor-lang'); 
+				  		echo _e('JA', 'child-sponsor-lang');
 				  		} else {echo _e('NEIN', 'child-sponsor-lang');}
-				  ?> 
+				  ?>
 
                 <hr>
-                
+
                <p>Se avete domande sul vostro sostegno, siamo volentieri a vostra disposizione: <br/>
 	               Tel: 031 552 21 24(il martedì e il giovedì: 8h00-16h00)<br/>
 	               o per email a: info@compassion.ch</p>
@@ -296,7 +299,7 @@
 				  Grazie con tutto il cuore per il vostro impegno concreto che cambia la vita di un bambino.
 				  <br/>Carole Rochat per il team di Compassion Svizzera</p>
             </div>
-            
+
             <p style="text-align: center;padding-top:30px"><img src="<?php echo get_template_directory_uri(); ?>/assets/img/compassion-logo-dark-it.png" width="242" height="93" alt="" /><p>
 
 

--- a/child-sponsor/templates/frontend/step-1.php
+++ b/child-sponsor/templates/frontend/step-1.php
@@ -6,6 +6,9 @@ $msk = isset($_SESSION['child-sponsor']['msk_participant_name']) || isset($_SESS
 
 $wapr = isset($_SESSION['utm_source']) && $_SESSION['utm_source']=='wrpr';
 
+// Partner must be younger than this limit for Write&Pray sponsorship
+$wapr_age_limit = 25;
+
 if ($msk) {
     $_SESSION['child-sponsor']['consumer_source'] = $_SESSION['consumer_source'];
     $_SESSION['child-sponsor']['consumer_source_text'] = $_SESSION['consumer_source_text'];
@@ -111,7 +114,18 @@ if ($msk) {
                     <label class="text-left middle"><?php _e('Geburtsdatum', 'child-sponsor-lang'); ?></label>
                 </div>
                 <div class="small-8 columns">
-                    <input type="text" id="datepicker" placeholder="31/12/2000" class="input-field" required data-msg="<?php _e('Geburtsdatum erforderlich', 'child-sponsor-lang'); ?>" name="birthday" value="<?php echo (isset($session_data['birthday'])) ? $session_data['birthday'] : ''; ?>">
+                    <input type="text"
+                           id="datepicker"
+                           name="birthday"
+                           placeholder="31/12/2000"
+                           class="input-field"
+                           required
+                           value="<?php echo (isset($session_data['birthday'])) ? $session_data['birthday'] : ''; ?>"
+                           data-default-msg="<?php _e('Geburtsdatum erforderlich', 'child-sponsor-lang'); ?>"
+                           data-wrpr="<?= $wapr ? "true" : "false"; ?>"
+                           data-wrpr-age-limit="<?= $wapr_age_limit; ?>"
+                           data-wrpr-age-limit-msg="<?php _e("Write&Pray Sponsorship are reserved for people under 25. Click here to reach the general sponsorship page", 'child-sponsor-lang'); ?>"
+                    />
                 </div>
             </div>
 
@@ -153,7 +167,7 @@ if ($msk) {
 
 			<!--              Writeandpraystuff  -->
 
-              <?php if (!$wapr) { ?>
+<?php if (!$wapr) { ?>
 
             <h4 class="text-uppercase" id="bank"><?php _e('Zahlungsweise', 'child-sponsor-lang'); ?></h4>
 				<div class="row">
@@ -176,17 +190,23 @@ if ($msk) {
 
                 </div>
                 </div>
-         <?php } else { ?>
-
+<?php } else { ?>
        <h4 class="text-uppercase" id="Patenschaftplus"><?php _e('Write & Pray', 'child-sponsor-lang'); ?></h4>
-             	<div class="row">
-                <div class="small-12 columns">
-	            <input class="" type="checkbox" required  <?php echo (isset($session_data['writepray']) && $session_data['writepray']['checkbox'] == 'on') ? 'checked' : ''; ?> name="writepray[checkbox]"> <span class="marg-left-10 strong-statment">  <?php _e('JA', 'child-sponsor-lang'); ?></span>
-	             <p class="marg-top-10"><?php _e('Ich engagiere mich für mein Patenkind zu beten und ihm regelmässsig zu schreiben.  Ich habe verstanden, dass eine andere Person die Finanzierung dieser Patenschaft übernimmt und ich gegenüber dem Kind der/die offizielle Pate/Patin bin.', 'child-sponsor-lang')?></p>
+            <div class="row">
+                <div class="small-12 columns radio-wrapper">
+                    <label><input type="radio" required data-msg="<?php _e('Angabe erforderlich', 'child-sponsor-lang'); ?>" name="writepray" value="WRPR">
+                      <?php _e('Ich engagiere mich für mein Patenkind zu beten und ihm regelmässsig zu schreiben.  Ich habe verstanden, dass eine andere Person die Finanzierung dieser Patenschaft übernimmt und ich gegenüber dem Kind der/die offizielle Pate/Patin bin.', 'child-sponsor-lang')?></label>
+                    <label><input type="radio" required data-msg="<?php _e('Angabe erforderlich', 'child-sponsor-lang'); ?>" name="writepray" value="WRPR+DON">
+                        <?php _e('Je m\'engage à [...] et je peux contribuer mensuellement à hauteur de :', 'child-sponsor-lang')?></label>
                 </div>
+            </div>
+            <div class="row hide" id="writepray-contribution" >
+                <div class="small-4 columns marg-top-10">
+                    <input class="ignore" type="number" min='1' max='42' placeholder="20.- CHF" required data-msg="<?php _e('Angabe erforderlich', 'child-sponsor-lang'); ?>" name="writepray-contribution" value="">
                 </div>
+            </div>
 
-          <?php } ?>
+<?php } ?>
 
           <!--        end Writeandpraystuff  -->
 


### PR DESCRIPTION
related https://github.com/CompassionCH/compassion-switzerland/pull/1045

Il y a deux nouveaux texts à corriger/traduire:

`child-sponsor/templates/frontend/step-1.php` ligne 127 - Texte lorsque le parrain a plus de 25 ans pour le rediriger vers un parrainage normal
`child-sponsor/templates/frontend/step-1.php` ligne 200 - Texte pour permettre au nouveau parrain de contribuer au payment mensuel du parrainage

le 2e texte est repris dans les mails de confirmations il faut donc aussi l'adapter (vers la ligne 200)
