### PR TITLE
Change forms autofill for new way of sending mailings.

### DIFF
--- a/cf7-pf_oli_klay/templates/cadeau/inputs.php
+++ b/cf7-pf_oli_klay/templates/cadeau/inputs.php
@@ -3,7 +3,7 @@
         <label class="text-left middle"><?php _e('Mein Betrag in CHF', 'donation-form'); ?></label>
     </div>
     <div class="small-8 columns">
-        <input type="text" placeholder="<?php _e('bitte nur Zahlen', 'donation-form'); ?>"required data-msg="<?php _e('Betrag erforderlich', 'donation-form'); ?>" class="input-field" name="wert" value="<?php echo (isset($session_data['wert'])) ? $session_data['wert'] : ''; ?>">
+        <input type="text" placeholder="<?php _e('bitte nur Zahlen', 'donation-form'); ?>"required data-msg="<?php _e('Betrag erforderlich', 'donation-form'); ?>" class="input-field" name="wert" value="<?php echo $_SESSION["fund_amount"]?>">
     </div>
 </div>
 <div class="row">
@@ -13,10 +13,10 @@
     <div class="small-8 columns">
         <div class="select-wrapper">
             <select name="fonds" id="fonds" class="input-field">
-                <option value="gift_birthday" <?php echo (isset($session_data['fonds']) && $session_data['fonds'] == "gift_birthday") ? 'selected' : '' ?>><?php _e('Geburtstagsgeschenk', 'donation-form'); ?></option>
-                <option value="gift_family" <?php echo (isset($session_data['fonds']) && $session_data['fonds'] == "gift_family") ? 'selected' : '' ?>><?php _e('Familiengeschenk', 'donation-form'); ?></option>
-                <option value="gift_gen" <?php echo (isset($session_data['fonds']) && $session_data['fonds'] == "gift_gen") ? 'selected' : '' ?>><?php _e('Allgemeines Geschenk', 'donation-form'); ?></option>
-                <option value="gift_project" <?php echo (isset($session_data['fonds']) && $session_data['fonds'] == "gift_project") ? 'selected' : '' ?>><?php _e('Geschenk ans Kinderzentrum', 'donation-form'); ?></option>
+                <option value="gift_birthday" <?php echo ($_SESSION["fund_code"] == "gift_birthday") ? 'selected' : '' ?>><?php _e('Geburtstagsgeschenk', 'donation-form'); ?></option>
+                <option value="gift_family" <?php echo ($_SESSION["fund_code"] == "gift_family") ? 'selected' : '' ?>><?php _e('Familiengeschenk', 'donation-form'); ?></option>
+                <option value="gift_gen" <?php echo ($_SESSION["fund_code"] == "gift_gen") ? 'selected' : '' ?>><?php _e('Allgemeines Geschenk', 'donation-form'); ?></option>
+                <option value="gift_project" <?php echo ($_SESSION["fund_code"] == "gift_project") ? 'selected' : '' ?>><?php _e('Geschenk ans Kinderzentrum', 'donation-form'); ?></option>
             </select>
         </div>
     </div>
@@ -26,6 +26,6 @@
         <label class="text-left middle"><?php _e('Patenkindnummer', 'donation-form'); ?></label>
     </div>
     <div class="small-8 columns">
-        <input type="text" required data-msg="<?php _e('Patenkindnummer erforderlich', 'donation-form'); ?>" placeholder="<?php _e('ie : BO012301234', 'donation-form'); ?>" class="input-field" id="refenfant" name="refenfant" value="<?php echo (isset($session_data['refenfant'])) ? $session_data['refenfant'] : ''; ?>">
+        <input type="text" required data-msg="<?php _e('Patenkindnummer erforderlich', 'donation-form'); ?>" placeholder="<?php _e('ie : BO012301234', 'donation-form'); ?>" class="input-field" id="refenfant" name="refenfant" value="<?php echo $_SESSION["child_ref"]?>">
     </div>
 </div>

--- a/cf7-pf_oli_klay/templates/csp/inputs.php
+++ b/cf7-pf_oli_klay/templates/csp/inputs.php
@@ -53,7 +53,7 @@
                placeholder="<?php _e('bitte nur Zahlen', 'donation-form'); ?>"
                data-msg="<?php _e('Betrag erforderlich', 'donation-form'); ?>" class="input-field"
                name="wert"
-               value="<?php echo (isset($session_data['wert'])) ? $session_data['wert'] : ''; ?>">
+               value="<?php echo $_SESSION["fund_amount"]?>">
     </div>
 </div>
 
@@ -65,9 +65,9 @@
         <div class="select-wrapper">
             <select name="fonds" id="fonds" class="input-field">
                 <option value="csp_mensuel_30"
-                        selected="selected" <?php echo (isset($session_data['fonds']) && $session_data['fonds'] == "mensuel 30") ? 'selected' : '' ?>><?php _e('Monatliche Spende von CHF 30.-', 'donation-form'); ?></option>
-                <option value="csp_mensuel_60" <?php echo (isset($session_data['fonds']) && $session_data['fonds'] == "mensuel 60") ? 'selected' : '' ?>><?php _e('Monatliche Spende von CHF 60.-', 'donation-form'); ?></option>
-                <option value="csp_mensuel_90" <?php echo (isset($session_data['fonds']) && $session_data['fonds'] == "mensuel 90") ? 'selected' : '' ?>><?php _e('Monatliche Spende von CHF 90.-', 'donation-form'); ?></option>
+                        selected="selected" <?php echo ($_SESSION["fund_code"] == "mensuel 30") ? 'selected' : '' ?>><?php _e('Monatliche Spende von CHF 30.-', 'donation-form'); ?></option>
+                <option value="csp_mensuel_60" <?php echo ($_SESSION["fund_code"] == "mensuel 60") ? 'selected' : '' ?>><?php _e('Monatliche Spende von CHF 60.-', 'donation-form'); ?></option>
+                <option value="csp_mensuel_90" <?php echo ($_SESSION["fund_code"] == "mensuel 90") ? 'selected' : '' ?>><?php _e('Monatliche Spende von CHF 90.-', 'donation-form'); ?></option>
             </select>
         </div>
         <p class="small"> <?php _e('Nach deiner ersten Spende wird dir Compassion Schweiz einen Einzahlungsschein für die weiteren Spenden zusenden.', 'donation-form'); ?></p>

--- a/cf7-pf_oli_klay/templates/donation-form.php
+++ b/cf7-pf_oli_klay/templates/donation-form.php
@@ -76,7 +76,7 @@
                         <label class="text-left middle"><?php _e('Nachname', 'child-sponsor-lang'); ?></label>
                     </div>
                     <div class="small-8 columns">
-                        <input type="text" required data-msg="<?php _e('Nachname erforderlich', 'child-sponsor-lang'); ?>" class="input-field" id="last_name" name="last_name" value="<?php echo (isset($session_data['last_name'])) ? $session_data['last_name'] : ''; ?>">
+                        <input type="text" required data-msg="<?php _e('Nachname erforderlich', 'child-sponsor-lang'); ?>" class="input-field" id="last_name" name="last_name" value="<?php echo $_SESSION["pname"]?>">
                     </div>
                 </div>
                 <div class="row">
@@ -84,7 +84,7 @@
                         <label class="text-left middle"><?php _e('Vorname', 'child-sponsor-lang'); ?></label>
                     </div>
                     <div class="small-8 columns">
-                        <input type="text" required data-msg="<?php _e('Vorname erforderlich', 'child-sponsor-lang'); ?>" class="input-field" id="first_name" name="first_name" value="<?php echo (isset($session_data['first_name'])) ? $session_data['first_name'] : ''; ?>">
+                        <input type="text" required data-msg="<?php _e('Vorname erforderlich', 'child-sponsor-lang'); ?>" class="input-field" id="first_name" name="first_name" value="<?php echo $_SESSION["firstname"]?>">
                     </div>
                 </div>
                 <div class="row">
@@ -92,7 +92,7 @@
                         <label class="text-left middle"><?php _e('Strasse/Hausnr.', 'child-sponsor-lang'); ?></label>
                     </div>
                     <div class="small-8 columns">
-                        <input type="text" required data-msg="<?php _e('Strasse erforderlich', 'child-sponsor-lang'); ?>" class="input-field" id="street" name="street" value="<?php echo (isset($session_data['street'])) ? $session_data['street'] : ''; ?>">
+                        <input type="text" required data-msg="<?php _e('Strasse erforderlich', 'child-sponsor-lang'); ?>" class="input-field" id="street" name="street" value="<?php echo $_SESSION["pstreet"]?>">
                     </div>
                 </div>
                 <div class="row">
@@ -100,10 +100,10 @@
                         <label class="text-left middle"><?php _e('PLZ/Ort', 'child-sponsor-lang'); ?></label>
                     </div>
                     <div class="small-2 columns">
-                        <input type="text" required data-msg="<?php _e('PLZ erforderlich', 'child-sponsor-lang'); ?>" class="input-field" id="zipcode" name="zipcode" value="<?php echo (isset($session_data['zipcode'])) ? $session_data['zipcode'] : ''; ?>">
+                        <input type="text" required data-msg="<?php _e('PLZ erforderlich', 'child-sponsor-lang'); ?>" class="input-field" id="zipcode" name="zipcode" value="<?php echo $_SESSION["pzip"]?>">
                     </div>
                     <div class="small-6 columns no-padding-left">
-                        <input type="text" required data-msg="<?php _e('Stadt erforderlich', 'child-sponsor-lang'); ?>" class="input-field" id="city" name="city" value="<?php echo (isset($session_data['city'])) ? $session_data['city'] : ''; ?>">
+                        <input type="text" required data-msg="<?php _e('Stadt erforderlich', 'child-sponsor-lang'); ?>" class="input-field" id="city" name="city" value="<?php echo $_SESSION["pcity"]?>">
                     </div>
                 </div>
                 <div class="row">
@@ -111,7 +111,7 @@
                         <label class="text-left middle"><?php _e('Land', 'child-sponsor-lang'); ?></label>
                     </div>
                     <div class="small-8 columns">
-                        <input type="text" required data-msg="<?php _e('Länd erforderlich', 'child-sponsor-lang'); ?>" class="input-field" id="country" name="country" value="<?php echo (isset($session_data['country'])) ? $session_data['country'] : ''; ?>">
+                        <input type="text" required data-msg="<?php _e('Länd erforderlich', 'child-sponsor-lang'); ?>" class="input-field" id="country" name="country" value="<?php echo $_SESSION["pcountry"]?>">
                     </div>
                 </div>
                 <div class="row">
@@ -119,7 +119,7 @@
                         <label class="text-left middle"><?php _e('E-Mail-Adresse', 'child-sponsor-lang'); ?></label>
                     </div>
                     <div class="small-8 columns">
-                        <input type="email" class="input-field" required data-msg="<?php _e('E-Mail-Adresse erforderlich', 'child-sponsor-lang'); ?>" id="email" name="email" value="<?php echo (isset($session_data['email'])) ? $session_data['email'] : ''; ?>">
+                        <input type="email" class="input-field" required data-msg="<?php _e('E-Mail-Adresse erforderlich', 'child-sponsor-lang'); ?>" id="email" name="email" value="<?php echo $_SESSION["email"]?>">
                     </div>
                 </div>
 

--- a/cf7-pf_oli_klay/templates/frontend/inputs.php
+++ b/cf7-pf_oli_klay/templates/frontend/inputs.php
@@ -3,7 +3,7 @@
         <label class="text-left middle"><?php _e('Betrag deiner Spende in CHF', 'donation-form'); ?></label>
     </div>
     <div class="small-8 columns">
-        <input type="text" id="wert" placeholder="<?php _e('bitte nur Zahlen', 'donation-form'); ?>" required data-msg="<?php _e('Betrag erforderlich', 'donation-form'); ?>" class="input-field" name="wert" value="<?php echo (isset($session_data['wert'])) ? $session_data['wert'] : ''; ?>">
+        <input type="text" id="wert" placeholder="<?php _e('bitte nur Zahlen', 'donation-form'); ?>" required data-msg="<?php _e('Betrag erforderlich', 'donation-form'); ?>" class="input-field" name="wert" value="<?php echo $_SESSION["fund_amount"]?>">
     </div>
 </div>
 <div class="row">
@@ -30,13 +30,13 @@
     <div class="small-8 columns">
         <div class="select-wrapper">
             <select name="fonds" id="fonds" class="input-field">
-                <option value="humanitaire" <?php echo (isset($session_data['fonds']) && $session_data['fonds'] == "humanitaire") ? 'selected' : '' ?>><?php _e('Aktuelle Nothilfe', 'donation-form'); ?></option>
-                <option value="noel" <?php echo (isset($session_data['fonds']) && $session_data['fonds'] == "noel") ? 'selected' : '' ?>><?php _e('Weihnachtsgeschenk', 'donation-form'); ?></option>
-                <option value="wash" <?php echo (isset($session_data['fonds']) && $session_data['fonds'] == "wash") ? 'selected' : '' ?>><?php _e('Sauberes Wasser', 'donation-form'); ?></option>
-                <option value="csp" <?php echo (isset($session_data['fonds']) && $session_data['fonds'] == "csp") ? 'selected' : '' ?>><?php _e('Babys und Müttern helfen', 'donation-form'); ?></option>
-                <option value="sansparrain" <?php echo (isset($session_data['fonds']) && $session_data['fonds'] == "sansparrain") ? 'selected' : '' ?>><?php _e('Kinder, die ihren Paten verloren haben', 'donation-form'); ?></option>
-                <option value="medical" <?php echo (isset($session_data['fonds']) && $session_data['fonds'] == "medical") ? 'selected' : '' ?>><?php _e('Medizinische Hilfe', 'donation-form'); ?></option>
-                <option value="bible" <?php echo (isset($session_data['fonds']) && $session_data['fonds'] == "bible") ? 'selected' : '' ?>><?php _e('Bibelfonds', 'donation-form'); ?></option>
+                <option value="humanitaire" <?php echo ($_SESSION["fund_code"] == "humanitaire") ? 'selected' : '' ?>><?php _e('Aktuelle Nothilfe', 'donation-form'); ?></option>
+                <option value="noel" <?php echo ($_SESSION["fund_code"] == "noel") ? 'selected' : '' ?>><?php _e('Weihnachtsgeschenk', 'donation-form'); ?></option>
+                <option value="wash" <?php echo ($_SESSION["fund_code"] == "wash") ? 'selected' : '' ?>><?php _e('Sauberes Wasser', 'donation-form'); ?></option>
+                <option value="csp" <?php echo ($_SESSION["fund_code"] == "csp") ? 'selected' : '' ?>><?php _e('Babys und Müttern helfen', 'donation-form'); ?></option>
+                <option value="sansparrain" <?php echo ($_SESSION["fund_code"] == "sansparrain") ? 'selected' : '' ?>><?php _e('Kinder, die ihren Paten verloren haben', 'donation-form'); ?></option>
+                <option value="medical" <?php echo ($_SESSION["fund_code"] == "medical") ? 'selected' : '' ?>><?php _e('Medizinische Hilfe', 'donation-form'); ?></option>
+                <option value="bible" <?php echo ($_SESSION["fund_code"] == "bible") ? 'selected' : '' ?>><?php _e('Bibelfonds', 'donation-form'); ?></option>
             </select>
         </div>
     </div>

--- a/child-sponsor/templates/email/user-new-sponsor.php
+++ b/child-sponsor/templates/email/user-new-sponsor.php
@@ -161,7 +161,6 @@
             ?>
             <h1 style="text-align: center; padding: 25px 0;">Un grand MERCI pour ton engagement</h1>
 
-
 			<div style="padding: 0 30px;">
 			 <p>
                  <?php  echo ($session_data['salutation'] == 'Herr') ? __('Lieber', 'compassion-letters') : __('Liebe', 'compassion-letters');?> <?php echo $session_data['first_name']; ?>, <br /><br />
@@ -179,18 +178,17 @@
                 <div style="padding: 0 30px;">
                     <p>
                         <?php echo ($session_data['salutation'] == 'Herr') ? __('Lieber', 'compassion-letters') : __('Liebe', 'compassion-letters');?> <?php  $salutation = apply_filters( 'wpml_object_id', $session_data['salutation'], 'post', TRUE);
-                        echo _e($salutation, 'child-sponsor-lang');?> <?php echo $session_data['first_name']; ?> <?php echo $session_data['last_name']; ?> <br /><br />
-                        Bienvenue dans la grande famille de Compassion. Vous avez décidé de parrainer <?php echo $child_meta['name']; ?>. Merci de vous engager à changer la vie de cet enfant! C’est un jour de fête pour chaque enfant et sa famille lorsque les collaborateurs d’un centre d’accueil l’informent qu’un parrain s’intéresse à lui et a choisi de le soutenir. Vous êtes aujourd’hui la source d’une très grande joie! Au nom de <?php echo $child_meta['name']; ?>, MERCI !
-                    </p>
-                    <p> Vous recevrez dans les tous prochains jours toutes les informations concernant votre parrainage, par poste. Pour cela, merci de bien vérifier vos données ainsi que votre adresse postale.</p>
+	                    echo _e($salutation, 'child-sponsor-lang');?> <?php echo $session_data['first_name']; ?> <?php echo $session_data['last_name']; ?> <br /><br />
+			Bienvenue dans la grande famille de Compassion. Vous avez décidé de parrainer <?php echo $child_meta['name']; ?>. Merci de vous engager à changer la vie de cet enfant! C’est un jour de fête pour chaque enfant et sa famille lorsque les collaborateurs d’un centre d’accueil l’informent qu’un parrain s’intéresse à lui et a choisi de le soutenir. Vous êtes aujourd’hui la source d’une très grande joie! Au nom de <?php echo $child_meta['name']; ?>, MERCI !
+			 </p>
+			 <p> Vous recevrez dans les tous prochains jours toutes les informations concernant votre parrainage, par poste. Pour cela, merci de bien vérifier vos données ainsi que votre adresse postale.</p>
 
 
-                    <h4> Vous nous avez transmis les informations suivantes:</h4>
-                    <?php
+			<h4> Vous nous avez transmis les informations suivantes:</h4>
+<?php
                     }
 
                     ?>
-
           <div style="padding: 0 30px;">
 
 	          	<p>Je prends en charge le parrainage de:  <strong><?php echo $child_meta['name']; ?></strong></p>
@@ -294,7 +292,7 @@
 				}
 				}
 				?>
-              <?php
+<?php
               if ($wapr) {
               ?>
               <h3>Ta réponse à la question : Comment as-tu connu Compassion ?</h3>
@@ -327,7 +325,7 @@
 				  ?>
 
                 <hr>
-              <?php
+<?php
               if ($wapr) {
                   ?>
                   <p>Si tu as des questions au sujet de ton parrainage, nous restons volontiers à ta disposition: Téléphone: 024 434 21 24 (lundi à vendredi de 8h00 à 16h00) – Adresse e-mail:
@@ -339,7 +337,6 @@
               <?php
               }
               ?>
-
 
               <p>Merci du fond du cœur d’avoir choisi d’investir dans la vie d’un enfant. Michelle aux Philippines a grandi dans un quartier pauvre où régnait trafic et consommation de drogue et prostitution. Parrainée, elle a pu aller à l’école, suivre des études. Aujourd’hui, elle dirige l’ONG qu’elle a créée et vient en aide aux femmes victimes d’esclavage moderne. Votre parrainage va transformer une vie durablement.<br/><br/>
 				   Très cordialement,<br/>Carole Rochat pour l’équipe de Compassion Suisse</p>

--- a/child-sponsor/templates/email_it/user-new-sponsor.php
+++ b/child-sponsor/templates/email_it/user-new-sponsor.php
@@ -157,7 +157,8 @@
         <?php } else {   ?>
             <h1 style="text-align: center; padding: 25px 0;">Un grande GRAZIE per il vostro impegno</h1>
         <?php } ?>
-            <div style="padding: 0 30px;">
+
+			<div style="padding: 0 30px;">
 			 <p>
         <?php if ($wapr) {   ?>
 			<?php echo ($session_data['salutation'] == 'Herr') ? __('Lieber', 'compassion-letters') : __('Liebe', 'compassion-letters');?> <?php echo $session_data['first_name']; ?>  <br /><br />
@@ -170,15 +171,14 @@
         <?php } else {   ?>
 
                 <?php echo ($session_data['salutation'] == 'Herr') ? __('Lieber', 'compassion-letters') : __('Liebe', 'compassion-letters');?> <?php  $salutation = apply_filters( 'wpml_object_id', $session_data['salutation'], 'post', TRUE);
-                echo _e($salutation, 'child-sponsor-lang');?> <?php echo $session_data['first_name']; ?> <?php echo $session_data['last_name']; ?> <br /><br />
-                Avete deciso di sostenere <?php echo $child_meta['name']; ?>. Grazie del vostro impegno nel cambiare la vita di questo bambino! È difficile immaginare la gioia che i bambini sentono nel momento in cui i collaboratori dei Centri Compassion gli annunciano che dall'altra parte del globo c'è un sostenitore che si prende cura di loro. Oggi voi siete fonte di grande gioia! A nome di <?php echo $child_meta['name']; ?>, GRAZIE!
-                </p>
-                <p> Presto riceverete per posta tutte le informazioni per il vostro sostegno. Per questo, grazie di verificare i vostri dati e il vostro indirizzo postale.</p>
+	                    echo _e($salutation, 'child-sponsor-lang');?> <?php echo $session_data['first_name']; ?> <?php echo $session_data['last_name']; ?> <br /><br />
+			Avete deciso di sostenere <?php echo $child_meta['name']; ?>. Grazie del vostro impegno nel cambiare la vita di questo bambino! È difficile immaginare la gioia che i bambini sentono nel momento in cui i collaboratori dei Centri Compassion gli annunciano che dall'altra parte del globo c'è un sostenitore che si prende cura di loro. Oggi voi siete fonte di grande gioia! A nome di <?php echo $child_meta['name']; ?>, GRAZIE!
+			 </p>
+			 <p> Presto riceverete per posta tutte le informazioni per il vostro sostegno. Per questo, grazie di verificare i vostri dati e il vostro indirizzo postale.</p>
 
 
-                <h4> Avete trasmetto le informazioni seguenti:</h4>
-        <?php } ?>
-
+			<h4> Avete trasmetto le informazioni seguenti:</h4>
+<?php } ?>
 
           <div style="padding: 0 30px;">
 
@@ -252,7 +252,6 @@
                         ?>
                       <?php } ?>
                 <h3>Corrispondenza con <?php echo $child_meta['name']; ?></h3>
-
                    <?php
 	            if(!empty($session_data['language'])) {
 				foreach($session_data['language'] as $check) {
@@ -284,7 +283,7 @@
 				}
 				}
 				?>
-             <?php if ($wapr) {
+<?php if ($wapr) {
              ?>
 				<h3>La tua risposta alla domanda: Come ha conosciuto Compassion?</h3>
 
@@ -293,7 +292,6 @@
               <h3>La vostra risposta alla domanda: Come ha conosciuto Compassion?</h3>
 
               <?php } ?>
-
                <ul>
                    <li>
                        <?php
@@ -314,7 +312,7 @@
 				  ?>
 
                 <hr>
-              <?php if ($wapr) {
+<?php if ($wapr) {
               ?>
                <p>Se hai domande sul sostegno siamo a tua completa disposizione: <br/>
 	               Tel: 031 552 21 24(il martedì e il giovedì: 8h00-16h00)<br/>

--- a/compassion-letters/templates/email/admin-email.php
+++ b/compassion-letters/templates/email/admin-email.php
@@ -153,7 +153,6 @@
             <div style="padding: 0 30px;">
                 <h3>Daten:</h3>
                 <ul>
-                    <li><?php _e('Anrede', 'compassion'); ?>: <?php echo $form_data['salutation']; ?></li>
                     <li><?php _e('Name', 'compassion'); ?>: <?php echo $form_data['name']; ?></li>
                     <li><?php _e('E-Mail','compassion'); ?>: <?php echo $form_data['email']; ?></li>
                     <li><?php _e('Referenznummer','compassion'); ?>: <?php echo $form_data['referenznummer']; ?></li>

--- a/compassion-letters/templates/email/user-email.php
+++ b/compassion-letters/templates/email/user-email.php
@@ -152,7 +152,7 @@
 	            
 	            	<?php if ($form_data['template'] == 'christmas_web_2020'){ ?>
 					<p>
-                    <?php echo ($form_data['salutation'] == 'Herr') ? __('Lieber', 'compassion-letters') : __('Liebe', 'compassion-letters'); /* echo ' '.$form_data['salutation'];  */?> <?php echo $form_data['name']; ?>,<br />
+                    <?php echo $form_data['name']; ?>,<br />
                 
                 Merci d’avoir pris le temps d’écrire une carte de Noël à votre filleul/le.<br/> Recevoir une carte pour Noël, signifie pour beaucoup d’enfants parrainés au travers de Compassion, que quelqu’un pense à eux dans cette période si spéciale.
 
@@ -172,7 +172,7 @@
 
 
                 <p>
-                    <?php echo ($form_data['salutation'] == 'Herr') ? __('Lieber', 'compassion-letters') : __('Liebe', 'compassion-letters'); /* echo ' '.$form_data['salutation'];  */?> <?php echo $form_data['name']; ?>,<br />
+                    <?php echo $form_data['name']; ?>,<br />
                  Merci d’avoir pris le temps d’écrire une lettre à votre filleul. Les courriers sont une véritable source d’encouragement pour l'enfant parrainé. Ce dernier est toujours très heureux de les recevoir.<p>
 
 				 <p> Votre lettre va être traduite si nécessaire et lui être envoyée dans les meilleurs délais. Vous en trouverez également une copie dans ce message.<br/>

--- a/compassion-letters/templates/email_de/admin-email.php
+++ b/compassion-letters/templates/email_de/admin-email.php
@@ -153,7 +153,6 @@
             <div style="padding: 0 30px;">
                 <h3>Daten:</h3>
                 <ul>
-                    <li><?php _e('Anrede', 'compassion'); ?>: <?php echo $form_data['salutation']; ?></li>
                     <li><?php _e('Name', 'compassion'); ?>: <?php echo $form_data['name']; ?></li>
                     <li><?php _e('E-Mail','compassion'); ?>: <?php echo $form_data['email']; ?></li>
                     <li><?php _e('Patennummer','compassion'); ?>: <?php echo $form_data['Patennummer']; ?></li>

--- a/compassion-letters/templates/email_de/user-email.php
+++ b/compassion-letters/templates/email_de/user-email.php
@@ -151,7 +151,7 @@
 	            
 	            <?php if ($form_data['template'] == 'christmas_web_2020'){ ?>
 					<p>
-                    <?php echo ($form_data['salutation'] == 'Herr') ? __('Lieber', 'compassion-letters') : __('Liebe', 'compassion-letters'); /* echo ' '.$form_data['salutation'];  */?> <?php echo $form_data['name']; ?><br /><br />
+                    <?php echo $form_data['name']; ?><br /><br />
 
                 Danke, dass du dir Zeit genommen hast, deinem Patenkind eine Weihnachtskarte zu schreiben!
 			   	<br/> So zeigst du deinem Patenkind, dass du in dieser ganz besonderen Zeit an ihn/sie denkst.
@@ -172,7 +172,7 @@
 	            
 
                 <p>
-                    <?php echo ($form_data['salutation'] == 'Herr') ? __('Lieber', 'compassion-letters') : __('Liebe', 'compassion-letters'); /* echo ' '.$form_data['salutation'];  */?> <?php echo $form_data['name']; ?>,<br />
+                    <?php echo $form_data['name']; ?>,<br />
                     Danke, dass du dir Zeit genommen hast, deinem Patenkind zu schreiben. Die Patenbriefe sind eine grosse Ermutigung für die Kinder, und die Freude ist immer riesig, wenn ein Brief ankommt. <p>
 
 				 <p> Dein Brief wird nun wenn nötig übersetzt und dann so schnell wie möglich übermittelt. Wir schicken dir hier noch eine Kopie des Textes.<br/>

--- a/compassion-letters/templates/email_it/admin-email.php
+++ b/compassion-letters/templates/email_it/admin-email.php
@@ -153,7 +153,6 @@
             <div style="padding: 0 30px;">
                 <h3>Daten:</h3>
                 <ul>
-                    <li><?php _e('Anrede', 'compassion'); ?>: <?php echo $form_data['salutation']; ?></li>
                     <li><?php _e('Name', 'compassion'); ?>: <?php echo $form_data['name']; ?></li>
                     <li><?php _e('E-Mail','compassion'); ?>: <?php echo $form_data['email']; ?></li>
                     <li><?php _e('Referenznummer','compassion'); ?>: <?php echo $form_data['referenznummer']; ?></li>

--- a/compassion-letters/templates/email_it/user-email.php
+++ b/compassion-letters/templates/email_it/user-email.php
@@ -151,7 +151,7 @@
 	            
 	              <?php if ($form_data['template'] == 'christmas_web_2020'){ ?>
 					<p>
-                    <?php echo ($form_data['salutation'] == 'Herr') ? __('Lieber', 'compassion-letters') : __('Liebe', 'compassion-letters'); /* echo ' '.$form_data['salutation'];  */?> <?php echo $form_data['name']; ?>,<br /><br />
+                    <?php echo $form_data['name']; ?>,<br /><br />
                 
                Grazie per aver dedicato del tempo nello scrivere una cartolina di Natale al suo bambino.
 			   	<br/> Ricevere un biglietto per Natale significa per molti bambini sostenuti attraverso Compassion, che qualcuno sta pensando a loro in questo momento speciale.
@@ -173,7 +173,7 @@
 	            
 
                 <p>
-                    <?php echo ($form_data['salutation'] == 'Herr') ? __('Lieber', 'compassion-letters') : __('Liebe', 'compassion-letters'); /* echo ' '.$form_data['salutation'];  */?> <?php echo $form_data['name']; ?>,<br />
+                    <?php echo $form_data['name']; ?>,<br />
                  Grazie per il tempo che dedicate alla corrispondenza con il vostro bambino. Le lettere sono una vera fonte di incoraggiamento per il bambino sostenuto ed è sempre molto felice di riceverle.<p>
 
 				 <p> La vostra lettera sarà tradotta, se necessario, e verrà inviata al più presto. Troverete anche una copia della lettera in questo messaggio.<br/>

--- a/compassion-letters/templates/frontend/form.php
+++ b/compassion-letters/templates/frontend/form.php
@@ -29,19 +29,10 @@
         <div class="medium-12 large-6 column">
              <div class="row">
                 <div class="small-4 columns">
-                    <label class="text-left middle"><?php _e('Anrede', 'compassion-letters'); ?>*</label>
-                </div>
-                <div class="small-8 columns anrede radio-wrapper">
-                    <input id="radio_frau" required data-msg="<?php _e('Anrede erforderlich', 'compassion-letters'); ?>" type="radio" name="salutation" value="Frau" <?php echo (isset($session_data['salutation']) && $session_data['salutation'] == 'Frau') ? 'checked' : ''; ?>><label for="radio_frau"><?php _e('Frau', 'compassion-letters'); ?></label><input id="radio_herr" required data-msg="<?php _e('Anrede erforderlich', 'compassion-letters'); ?>" type="radio" name="salutation" value="Herr" <?php echo (isset($session_data['salutation']) && $session_data['salutation'] == 'Herr') ? 'checked' : ''; ?>><label for="radio_herr"><?php _e('Herr', 'compassion-letters'); ?></label>
-                </div>
-            </div>
-
-            <div class="row">
-                <div class="small-4 columns">
                     <label class="text-left middle"><?php _e('E-Mail', 'compassion-letters'); ?>*</label>
                 </div>
                 <div class="small-8 columns">
-                    <input type="email" id="email" required data-msg="<?php _e('E-Mailadresse erforderlich', 'compassion-letters'); ?>" class="input-field clear-pdf-on-change" name="email">
+                    <input type="email" id="email" required data-msg="<?php _e('E-Mailadresse erforderlich', 'compassion-letters'); ?>" class="input-field clear-pdf-on-change" name="email" value="<?php echo $_SESSION["email"]?>">
                 </div>
             </div>
             
@@ -50,7 +41,7 @@
                     <label class="text-left middle"><?php _e('Vorname, Nachname', 'compassion-letters'); ?>*</label>
                 </div>
                 <div class="small-8 columns">
-                    <input type="text" required data-msg="<?php _e('Name erforderlich', 'compassion-letters'); ?>" class="input-field clear-pdf-on-change" name="name" id="pname">
+                    <input type="text" required data-msg="<?php _e('Name erforderlich', 'compassion-letters'); ?>" class="input-field clear-pdf-on-change" name="name" id="pname" value="<?php echo $_SESSION["pname"]?>">
                 </div>
             </div>
 
@@ -60,7 +51,7 @@
                     <label class="text-left middle"><?php _e('Patennummer (ohne CH)', 'compassion-letters'); ?>*</label>
                 </div>
                 <div class="small-8 columns">
-                    <input type="text" placeholder="1510000" required data-msg-referenznummer="<?php _e('Bitte gültige Nummer eingeben (ohne CH)', 'compassion-letters') ?>" data-msg="<?php _e('Patennummer erforderlich', 'compassion-letters'); ?>" class="input-field clear-pdf-on-change" name="referenznummer" id="sponsor_ref">
+                    <input type="text" placeholder="1510000" required data-msg-referenznummer="<?php _e('Bitte gültige Nummer eingeben (ohne CH)', 'compassion-letters') ?>" data-msg="<?php _e('Patennummer erforderlich', 'compassion-letters'); ?>" class="input-field clear-pdf-on-change" name="referenznummer" id="sponsor_ref" value="<?php echo $_SESSION["sponsor_ref"]?>">
                 </div>
             </div>
 
@@ -69,7 +60,7 @@
                     <label class="text-left middle"><?php _e('Patenkindnummer', 'compassion-letters'); ?>*</label>
                 </div>
                 <div class="small-8 columns">
-                    <input type="text" placeholder="AB014900332" required data-msg="<?php _e('Patenkindnummer erforderlich', 'compassion-letters'); ?>" data-msg-patenkindnummer="<?php _e('Bitte gültige Patenkindnummer eingeben', 'compassion-letters') ?>" class="input-field clear-pdf-on-change" name="patenkind" id="child_ref">
+                    <input type="text" placeholder="AB014900332" required data-msg="<?php _e('Patenkindnummer erforderlich', 'compassion-letters'); ?>" data-msg-patenkindnummer="<?php _e('Bitte gültige Patenkindnummer eingeben', 'compassion-letters') ?>" class="input-field clear-pdf-on-change" name="patenkind" id="child_ref" value="<?php echo $_SESSION["child_ref"]?>">
                 </div>
             </div>
 
@@ -78,7 +69,8 @@
                     <label class="text-left middle"><?php _e('Nachricht', 'compassion-letters'); ?>*</label>
                 </div>
                 <div class="small-8 columns">
-                    <textarea maxlength="1500" placeholder="<?php _e('Um den Verlust deines Briefes zu vermeiden, empfehlen wir dir, diesen zuerst auf einem Word-Dokument zu schreiben und ihn danach hier einzufügen.', 'compassion-letters'); ?>" required data-msg="<?php _e('Nachricht erforderlich', 'compassion-letters'); ?>" name="message" class="input-field clear-pdf-on-change"></textarea>
+                    <textarea maxlength="1500" placeholder="<?php _e('Um den Verlust deines Briefes zu vermeiden, empfehlen wir dir, diesen zuerst auf einem Word-Dokument zu schreiben und ihn danach hier einzufügen.', 'compassion-letters'); ?>" required data-msg="<?php _e('Nachricht erforderlich', 'compassion-letters'); ?>" name="message" id="message" class="input-field clear-pdf-on-change">
+                        <?php echo urldecode($_SESSION["message"])?></textarea>
                     <p class="text-right letter-count-wrapper"><span class="letter-count">0</span> <?php _e('von 1300 Zeichen', 'compassion-letters'); ?></p>
                 </div>
             </div>

--- a/compassion-letters/templates/frontend/form_christmas.php
+++ b/compassion-letters/templates/frontend/form_christmas.php
@@ -97,21 +97,12 @@
     <div class="row">
 
         <div class="medium-12 large-6 column">
-             <div class="row">
-                <div class="small-4 columns">
-                    <label class="text-left middle"><?php _e('Anrede', 'compassion-letters'); ?>*</label>
-                </div>
-                <div class="small-8 columns anrede radio-wrapper">
-                    <input id="radio_frau" required data-msg="<?php _e('Anrede erforderlich', 'compassion-letters'); ?>" type="radio" name="salutation" value="Frau" <?php echo (isset($session_data['salutation']) && $session_data['salutation'] == 'Frau') ? 'checked' : ''; ?>><label for="radio_frau"><?php _e('Frau', 'compassion-letters'); ?></label><input id="radio_herr" required data-msg="<?php _e('Anrede erforderlich', 'compassion-letters'); ?>" type="radio" name="salutation" value="Herr" <?php echo (isset($session_data['salutation']) && $session_data['salutation'] == 'Herr') ? 'checked' : ''; ?>><label for="radio_herr"><?php _e('Herr', 'compassion-letters'); ?></label>
-                </div>
-            </div>
-
             <div class="row">
                 <div class="small-4 columns">
                     <label class="text-left middle"><?php _e('E-Mail', 'compassion-letters'); ?>*</label>
                 </div>
                 <div class="small-8 columns">
-                    <input type="email" id="email" required data-msg="<?php _e('E-Mailadresse erforderlich', 'compassion-letters'); ?>" class="input-field clear-pdf-on-change" name="email">
+                    <input type="email" id="email" required data-msg="<?php _e('E-Mailadresse erforderlich', 'compassion-letters'); ?>" class="input-field clear-pdf-on-change" name="email" value="<?php echo $_SESSION["email"]?>">
                 </div>
             </div>
             
@@ -120,7 +111,7 @@
                     <label class="text-left middle"><?php _e('Vorname, Nachname', 'compassion-letters'); ?>*</label>
                 </div>
                 <div class="small-8 columns">
-                    <input type="text" required data-msg="<?php _e('Name erforderlich', 'compassion-letters'); ?>" class="input-field clear-pdf-on-change" name="name" id="pname">
+                    <input type="text" required data-msg="<?php _e('Name erforderlich', 'compassion-letters'); ?>" class="input-field clear-pdf-on-change" name="name" id="pname" value="<?php echo $_SESSION["pname"]?>">
                 </div>
             </div>
 
@@ -130,7 +121,7 @@
                     <label class="text-left middle"><?php _e('Patennummer (ohne CH)', 'compassion-letters'); ?>*</label>
                 </div>
                 <div class="small-8 columns">
-                    <input type="text" placeholder="1510000" required data-msg-referenznummer="<?php _e('Bitte gültige Nummer eingeben (ohne CH)', 'compassion-letters') ?>" data-msg="<?php _e('Patennummer erforderlich', 'compassion-letters'); ?>" class="input-field clear-pdf-on-change" name="referenznummer" id="sponsor_ref">
+                    <input type="text" placeholder="1510000" required data-msg-referenznummer="<?php _e('Bitte gültige Nummer eingeben (ohne CH)', 'compassion-letters') ?>" data-msg="<?php _e('Patennummer erforderlich', 'compassion-letters'); ?>" class="input-field clear-pdf-on-change" name="referenznummer" id="sponsor_ref" value="<?php echo $_SESSION["sponsor_ref"]?>">
                 </div>
             </div>
 
@@ -139,7 +130,7 @@
                     <label class="text-left middle"><?php _e('Patenkindnummer', 'compassion-letters'); ?>*</label>
                 </div>
                 <div class="small-8 columns">
-                    <input type="text" placeholder="AB014900332" required data-msg="<?php _e('Patenkindnummer erforderlich', 'compassion-letters'); ?>" data-msg-patenkindnummer="<?php _e('Bitte gültige Patenkindnummer eingeben', 'compassion-letters') ?>" class="input-field clear-pdf-on-change" name="patenkind" id="child_ref">
+                    <input type="text" placeholder="AB014900332" required data-msg="<?php _e('Patenkindnummer erforderlich', 'compassion-letters'); ?>" data-msg-patenkindnummer="<?php _e('Bitte gültige Patenkindnummer eingeben', 'compassion-letters') ?>" class="input-field clear-pdf-on-change" name="patenkind" id="child_ref" value="<?php echo $_SESSION["child_ref"]?>">
                 </div>
             </div>
 


### PR DESCRIPTION
Autofill will now work on all pages and share the same variables accross the website. Possible parameters in the URL are the following:

- pname => full name or lastname of sponsor
- firstname => firstname of sponsor
- email => email of sponsor
- pstreet => street of sponsor
- pcity => city of sponsor
- pzip => zip of sponsor
- pcountry => country of sponsor
- sponsor_ref => ref of sponsor
- child_ref => ref of child
- fund_code => code of fund for donation selection
- fund_amount => amount of donation

Examples of working url that will prefill all form data:
https://devcomp.site/ecrire/?firstname=Emanuel&pname=Emanuel+%28Compassion%29+Cino&email=ecino%40compassion.ch&pstreet=Rue+Galil%C3%A9e+3&pcity=Yverdon-les-Bains&pzip=1400&pcountry=Switzerland&sponsor_ref=777&utm_source=Compassion+Suisse+Test&utm_campaign=248ff8c57a-new_tracking_7&utm_medium=email&utm_term=0_91468387b6-248ff8c57a-333017914
https://devcomp.site/formulaire-pour-dons/?firstname=Emanuel&pname=Emanuel+%28Compassion%29+Cino&email=ecino%40compassion.ch&pstreet=Rue+Galil%C3%A9e+3&pcity=Yverdon-les-Bains&pzip=1400&pcountry=Switzerland&sponsor_ref=777&utm_source=Compassion+Suisse+Test&utm_campaign=248ff8c57a-new_tracking_7&utm_medium=email&utm_term=0_91468387b6-248ff8c57a-333017914