### PR TITLE
Fix session data security

### DIFF
--- a/cf7-pf_oli_klay/cf7-pf_oli.php
+++ b/cf7-pf_oli_klay/cf7-pf_oli.php
@@ -152,7 +152,7 @@ class Compassion_Donation_Form {
         switch ($this->step) {
             case 'redirect';
                 $this->send_data($data);
-//                session_destroy();
+    //                session_destroy();
                 break;
         }
     }
@@ -300,8 +300,12 @@ class Compassion_Donation_Form {
     }
 
     private function cleanfordb($value) {
+        
+    // Convert special characters to their safe equivalents
+    $value = htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
 
-        return trim(filter_var($value));
+    // remove whitespaces from both ends and return value
+    return trim($value);
 
     }
 

--- a/cf7-pf_oli_klay/cf7-pf_oli.php
+++ b/cf7-pf_oli_klay/cf7-pf_oli.php
@@ -152,7 +152,7 @@ class Compassion_Donation_Form {
         switch ($this->step) {
             case 'redirect';
                 $this->send_data($data);
-    //                session_destroy();
+//                session_destroy();
                 break;
         }
     }
@@ -443,6 +443,8 @@ class Compassion_Donation_Form {
         $redirectionUrl = $client->getTransactionPaymentPageService()->paymentPageUrl($this->spaceId, $pfTransaction->getId());
 
         header('Location: ' . $redirectionUrl);
+
+        session_destroy();
 
     }
 


### PR DESCRIPTION
Related issue: [CP-253](https://compassion-ch.atlassian.net/browse/CP-253)

The `filter_var()` method was missing an argument and it's now better to use `htmlspecialchars()` instead.
Related documentation: https://www.php.net/manual/en/filter.filters.sanitize.php

The send_data() function was missing a `session_destroy()` call at its end.

I also added comment to clarify the code behavior.

[CP-253]: https://compassion-ch.atlassian.net/browse/CP-253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ