### PR TITLE
givewp-postfinance: use createdAt date and skip transaction without postfinance_id meta

### DIFF
--- a/postfinance-gateway-givewp/src/CheckoutFlexGateway.php
+++ b/postfinance-gateway-givewp/src/CheckoutFlexGateway.php
@@ -248,7 +248,7 @@ class CheckoutFlexGateway extends PaymentGateway
                         'child_id' => '',
                         'orderid' => $form_url,
                         'amount' => floatval($donation->amountInBaseCurrency()->formatToDecimal()),
-                        'time' => $donation->updatedAt->format('Y-m-d H:i:s'),
+                        'time' => $donation->createdAt->format('Y-m-d H:i:s'),
                         'fund' => $fundDescription,
                         'pf_payid' => $postfinanceTransactionId,
                         'pf_brand' => $paymentMethod,
@@ -333,7 +333,12 @@ class CheckoutFlexGateway extends PaymentGateway
 
             foreach ($pf_not_synced as $donation) {
                 $meta = get_post_meta($donation->ID);
-                $pf_id = $meta['postfinance_transaction_id'][0];
+                $pf_id = 0;
+                if (isset($meta['postfinance_transaction_id'])) {
+                    $pf_id = $meta['postfinance_transaction_id'][0];
+                } else {
+                    continue;
+                }
                 $transaction = $client->getTransactionService()->read($this->spaceId, $pf_id);
                 $pf_state = $transaction->getState();
                 $give_donation = Donation::find($donation->ID);


### PR DESCRIPTION
Solves 2 bugs:
- some buggy transactions had no postfinance_transaction_id meta
- the donation date taken for Odoo was the modified date. Since we change the status when synchronizing, this was not the original date. We now use createdAt